### PR TITLE
build: use entrypoint instead cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY inb /app
-CMD [ "python", "inb.py" ]
+ENTRYPOINT [ "python", "inb.py" ]

--- a/README.md
+++ b/README.md
@@ -113,14 +113,14 @@ Usage: inb.py search [OPTIONS]
   you encounter error LinkedInSessionExpiredException.
 
     ./inb/inb.py search --email "username" --password "password"
-      --keyword "Software developer" --refersh-cookies
+      --keyword "Software developer" --refresh-cookies
 
   Also, for security purpose you can omit the --pasword argument over the
   command-line and later on executing the tool you'll be prompted to enter
   your password which will be hidden even after pressing keystrokes.
 
     ./inb/inb.py search --email "username" --keyword "Software developer"
-      --refersh-cookies
+      --refresh-cookies
 
 Options:
   --email TEXT              LinkedIn username.  [required]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ git clone https://github.com/joshiayush/inb.git
 To use the app with docker, you can use the following command:
 
 ```shell
-docker build -t inb . && docker run -it inb
+docker build -t inb . && docker run -it inb search --email ayush854032@gmail.com --password xxx-xxx-xxx \
+  --keyword 'Software Engineer'
 ```
 
 <div align="right">


### PR DESCRIPTION
It is necessary to use `ENTRYPOINT` instead of `CMD` because we need to pass parameters to the execution.